### PR TITLE
User rsvps

### DIFF
--- a/app/graphql/mutations/create_user_event.rb
+++ b/app/graphql/mutations/create_user_event.rb
@@ -1,0 +1,25 @@
+class Mutations::CreateUserEvent < Mutations::BaseMutation 
+  argument :user_id, String, required: true 
+  argument :event_id, String, required: true
+
+  field :user_event, Types::UserEventType, null: false 
+  field :errors, [String], null: false
+  field :event, Types::EventType, null: false 
+
+  def resolve(user_id:, event_id:)
+    uv = UserEvent.new(user_id: user_id.to_s, event_id: event_id.to_s)
+    if uv.save 
+      event = Event.find(event_id)
+      event.update(rsvps: event.user_events.count)
+      {
+        user_event: uv, 
+        errors: []
+      }
+    else 
+      {
+        user_event: nil, 
+        errors: uv.errors.full_messages
+      }
+    end
+  end
+end

--- a/app/graphql/mutations/create_user_event.rb
+++ b/app/graphql/mutations/create_user_event.rb
@@ -1,16 +1,16 @@
 class Mutations::CreateUserEvent < Mutations::BaseMutation 
-  argument :user_id, String, required: true 
-  argument :event_id, String, required: true
+  argument :user_id, Integer, required: true 
+  argument :event_id, Integer, required: true
 
   field :user_event, Types::UserEventType, null: false 
   field :errors, [String], null: false
   field :event, Types::EventType, null: false 
 
   def resolve(user_id:, event_id:)
-    uv = UserEvent.new(user_id: user_id.to_s, event_id: event_id.to_s)
+    uv = UserEvent.new(user_id: user_id, event_id: event_id)
     if uv.save 
       event = Event.find(event_id)
-      event.update(rsvps: event.user_events.count)
+      event.update(rsvps: event.user_events.count) 
       {
         user_event: uv, 
         errors: []

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -16,6 +16,6 @@ module Types
     field :state, String
     field :zip, Integer
     field :host, Integer
-    
+
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_user, mutation: Mutations::CreateUser
+    field :create_user_event, mutation: Mutations::CreateUserEvent
   end
 end

--- a/db/migrate/20220831215954_add_rsvps_to_events.rb
+++ b/db/migrate/20220831215954_add_rsvps_to_events.rb
@@ -1,0 +1,5 @@
+class AddRsvpsToEvents < ActiveRecord::Migration[7.0]
+  def change
+    add_column :events, :rsvps, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_001707) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_31_215954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -28,6 +28,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_001707) do
     t.string "state"
     t.integer "zip"
     t.integer "host"
+    t.integer "rsvps", default: 0
   end
 
   create_table "user_events", force: :cascade do |t|

--- a/spec/fixtures/vcr_cassettes/MapFacade/create_cords/returns_lat_and_long_cords.yml
+++ b/spec/fixtures/vcr_cassettes/MapFacade/create_cords/returns_lat_and_long_cords.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/geocoding/v1/address?key=<map_api_key>&location=Denver,CO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Tue, 30 Aug 2022 20:08:52 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1732'
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Geocodetransactioncount:
+      - '1'
+      Last-Modified:
+      - Tue, 30 Aug 2022 20:08:52 GMT
+      Pragma:
+      - no-cache
+      Reversegeocodetransactioncount:
+      - '0'
+      Set-Cookie:
+      - JSESSIONID=F383B0A69612C5C6B0105EA441F30778; Path=/; HttpOnly
+      Status:
+      - success
+      Transactionweight:
+      - '1.0'
+    body:
+      encoding: UTF-8
+      string: '{"info":{"statuscode":0,"copyright":{"text":"\u00A9 2022 MapQuest,
+        Inc.","imageUrl":"http://api.mqcdn.com/res/mqlogo.gif","imageAltText":"\u00A9
+        2022 MapQuest, Inc."},"messages":[]},"options":{"maxResults":-1,"thumbMaps":true,"ignoreLatLngInput":false},"results":[{"providedLocation":{"location":"Denver,CO"},"locations":[{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"Denver","adminArea5Type":"City","adminArea4":"Denver
+        County","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A5XAX","geocodeQuality":"CITY","dragPoint":false,"sideOfStreet":"N","linkId":"282041090","unknownInput":"","type":"s","latLng":{"lat":39.738453,"lng":-104.984853},"displayLatLng":{"lat":39.738453,"lng":-104.984853},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=<map_api_key>&type=map&size=225,160&locations=39.738453,-104.984853|marker-sm-50318A-1&scalebar=true&zoom=12&rand=81332214"},{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"","adminArea5Type":"City","adminArea4":"Denver
+        County","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A4XAX","geocodeQuality":"COUNTY","dragPoint":false,"sideOfStreet":"N","linkId":"282932003","unknownInput":"","type":"s","latLng":{"lat":39.738453,"lng":-104.984853},"displayLatLng":{"lat":39.738453,"lng":-104.984853},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=<map_api_key>&type=map&size=225,160&locations=39.738453,-104.984853|marker-sm-50318A-2&scalebar=true&zoom=9&rand=1865340970"}]}]}'
+  recorded_at: Tue, 30 Aug 2022 20:08:52 GMT
+recorded_with: VCR 6.1.0

--- a/spec/fixtures/vcr_cassettes/MapService/get_cords/returns_lat_and_long_cords.yml
+++ b/spec/fixtures/vcr_cassettes/MapService/get_cords/returns_lat_and_long_cords.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.mapquestapi.com/geocoding/v1/address?key=<map_api_key>&location=Denver,CO
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v2.5.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Tue, 30 Aug 2022 20:08:53 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Content-Length:
+      - '1735'
+      Access-Control-Allow-Methods:
+      - OPTIONS,GET,POST
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, must-revalidate
+      Expires:
+      - Mon, 20 Dec 1998 01:00:00 GMT
+      Geocodetransactioncount:
+      - '1'
+      Last-Modified:
+      - Tue, 30 Aug 2022 20:08:53 GMT
+      Pragma:
+      - no-cache
+      Reversegeocodetransactioncount:
+      - '0'
+      Set-Cookie:
+      - JSESSIONID=686AFC3AB7C869CAB29D41C14D2EEBFD; Path=/; HttpOnly
+      Status:
+      - success
+      Transactionweight:
+      - '1.0'
+    body:
+      encoding: UTF-8
+      string: '{"info":{"statuscode":0,"copyright":{"text":"\u00A9 2022 MapQuest,
+        Inc.","imageUrl":"http://api.mqcdn.com/res/mqlogo.gif","imageAltText":"\u00A9
+        2022 MapQuest, Inc."},"messages":[]},"options":{"maxResults":-1,"thumbMaps":true,"ignoreLatLngInput":false},"results":[{"providedLocation":{"location":"Denver,CO"},"locations":[{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"Denver","adminArea5Type":"City","adminArea4":"Denver
+        County","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A5XAX","geocodeQuality":"CITY","dragPoint":false,"sideOfStreet":"N","linkId":"282041090","unknownInput":"","type":"s","latLng":{"lat":39.738453,"lng":-104.984853},"displayLatLng":{"lat":39.738453,"lng":-104.984853},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=<map_api_key>&type=map&size=225,160&locations=39.738453,-104.984853|marker-sm-50318A-1&scalebar=true&zoom=12&rand=1943385921"},{"street":"","adminArea6":"","adminArea6Type":"Neighborhood","adminArea5":"","adminArea5Type":"City","adminArea4":"Denver
+        County","adminArea4Type":"County","adminArea3":"CO","adminArea3Type":"State","adminArea1":"US","adminArea1Type":"Country","postalCode":"","geocodeQualityCode":"A4XAX","geocodeQuality":"COUNTY","dragPoint":false,"sideOfStreet":"N","linkId":"282932003","unknownInput":"","type":"s","latLng":{"lat":39.738453,"lng":-104.984853},"displayLatLng":{"lat":39.738453,"lng":-104.984853},"mapUrl":"http://www.mapquestapi.com/staticmap/v5/map?key=<map_api_key>&type=map&size=225,160&locations=39.738453,-104.984853|marker-sm-50318A-2&scalebar=true&zoom=9&rand=-1912470471"}]}]}'
+  recorded_at: Tue, 30 Aug 2022 20:08:53 GMT
+recorded_with: VCR 6.1.0

--- a/spec/graphql/mutations/user_events/create_user_event_spec.rb
+++ b/spec/graphql/mutations/user_events/create_user_event_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Mutations::CreateUserEvent, type: :request do 
+  describe '.resolve' do 
+    it 'creates a user event and updates rsvps' do 
+      @user1 = User.create(user_name: "Garnet", email: "garnet@universe.com", image: "https://user-images.githubusercontent.com/99059063/187045147-667959c8-70f2-4fb3-b089-ca81f23a0310.png" , description: "We are a married lesbian couple with kids. We love to play sports and go on adventures!" , zip_code: 80220)
+      @user2 = User.create(user_name: "Pearl", email: "pearl@universe.com", image: "https://user-images.githubusercontent.com/99059063/187045202-04577eee-4d6b-4a6e-8d71-5b96aef2f6fc.png" , description: "I am a non-binary single parent looking for other enby parents.", zip_code: 80220)
+      @event1 = @user1.events.create(title: "Lunch at Denison Park", description: "We are getting together for a meet-and-greet at Denison Park.", time: '18:00:00', date: '2022-10-09', lat: "39.733", lng: "-104.904", address: "1105 Quebec St", city: "Denver", state: "CO", zip: 80220, host: @user1.id)
+
+      expect(UserEvent.count).to eq(1)
+      post '/graphql', params: { query: query }
+      expect(UserEvent.count).to eq(2)
+      expect(Event.last.rsvps).to eq(2)
+    end 
+
+    it 'returns a user event' do 
+      @user1 = User.create(user_name: "Garnet", email: "garnet@universe.com", image: "https://user-images.githubusercontent.com/99059063/187045147-667959c8-70f2-4fb3-b089-ca81f23a0310.png" , description: "We are a married lesbian couple with kids. We love to play sports and go on adventures!" , zip_code: 80220)
+      @user2 = User.create(user_name: "Pearl", email: "pearl@universe.com", image: "https://user-images.githubusercontent.com/99059063/187045202-04577eee-4d6b-4a6e-8d71-5b96aef2f6fc.png" , description: "I am a non-binary single parent looking for other enby parents.", zip_code: 80220)
+      @event1 = @user1.events.create(title: "Lunch at Denison Park", description: "We are getting together for a meet-and-greet at Denison Park.", time: '18:00:00', date: '2022-10-09', lat: "39.733", lng: "-104.904", address: "1105 Quebec St", city: "Denver", state: "CO", zip: 80220, host: @user1.id)
+
+      post '/graphql', params: { query: query }
+      json = JSON.parse(response.body)
+      data = json['data']['createUserEvent']
+      expect(data["userEvent"]).to include(
+        "userId"  => @user2.id,
+        "eventId" => @event1.id
+      )
+    end
+  end 
+
+  def query
+    <<~GQL
+      mutation {
+        createUserEvent(input: {
+          userId: "#{@user2.id}",
+          eventId: "#{@event1.id}"
+       }) { userEvent {
+          userId
+          eventId
+          id
+          createdAt
+        }
+        }
+      }
+    GQL
+  end
+end

--- a/spec/graphql/mutations/user_events/create_user_event_spec.rb
+++ b/spec/graphql/mutations/user_events/create_user_event_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Mutations::CreateUserEvent, type: :request do
       @event1 = @user1.events.create(title: "Lunch at Denison Park", description: "We are getting together for a meet-and-greet at Denison Park.", time: '18:00:00', date: '2022-10-09', lat: "39.733", lng: "-104.904", address: "1105 Quebec St", city: "Denver", state: "CO", zip: 80220, host: @user1.id)
 
       expect(UserEvent.count).to eq(1)
-      post '/graphql', params: { query: query }
+      post '/graphql', params: { query: query(user_id: @user2.id, event_id: @event1.id) }
       expect(UserEvent.count).to eq(2)
       expect(Event.last.rsvps).to eq(2)
     end 
@@ -18,7 +18,7 @@ RSpec.describe Mutations::CreateUserEvent, type: :request do
       @user2 = User.create(user_name: "Pearl", email: "pearl@universe.com", image: "https://user-images.githubusercontent.com/99059063/187045202-04577eee-4d6b-4a6e-8d71-5b96aef2f6fc.png" , description: "I am a non-binary single parent looking for other enby parents.", zip_code: 80220)
       @event1 = @user1.events.create(title: "Lunch at Denison Park", description: "We are getting together for a meet-and-greet at Denison Park.", time: '18:00:00', date: '2022-10-09', lat: "39.733", lng: "-104.904", address: "1105 Quebec St", city: "Denver", state: "CO", zip: 80220, host: @user1.id)
 
-      post '/graphql', params: { query: query }
+      post '/graphql', params: { query: query(user_id: @user2.id, event_id: @event1.id) }
       json = JSON.parse(response.body)
       data = json['data']['createUserEvent']
       expect(data["userEvent"]).to include(
@@ -28,12 +28,12 @@ RSpec.describe Mutations::CreateUserEvent, type: :request do
     end
   end 
 
-  def query
+  def query(user_id:, event_id:)
     <<~GQL
       mutation {
         createUserEvent(input: {
-          userId: "#{@user2.id}",
-          eventId: "#{@event1.id}"
+          userId: #{@user2.id},
+          eventId: #{@event1.id}
        }) { userEvent {
           userId
           eventId


### PR DESCRIPTION
## What this PR Covers  
  This PR adds a graphql mutation method to create user event and adds rsvps to event table. 
  
## Type of Content in PR  

- [ X] Spec Files
- [ ] Controllers / Facades / Poros
- [ ] Service Requests
- [ ] Route Change
- [ ] Gemfile Update
- [ ] Other:  


Is this a fully completed API Endpoint?  

- [ X] yes - API Endpoint:  Graphql createUserEvent
- [ ] no  

## Simplecov 100% Coverage  
- [ ] yes
- [ X] no  
If no, what files are not being covered?  95.6% - error handling needs tests. 

## Tested on Localhost/Postman  
- [ X] yes
- [ ] no  
If no, why was it not?  

## Additional Comments