### PR TITLE
Delete user event

### DIFF
--- a/app/graphql/mutations/delete_user_event.rb
+++ b/app/graphql/mutations/delete_user_event.rb
@@ -1,9 +1,10 @@
 class Mutations::DeleteUserEvent < Mutations::BaseMutation
-  argument :id, Integer, required: true
+  argument :user_id, Integer, required: true
+  argument :event_id, Integer, required: true
 
   type Types::UserEventType
 
-  def resolve(id:)
-    UserEvent.find(id).delete
+  def resolve(user_id:, event_id:)
+    UserEvent.find_by(user_id: user_id, event_id: event_id).delete
   end
 end

--- a/spec/graphql/mutations/user_events/delete_user_event_spec.rb
+++ b/spec/graphql/mutations/user_events/delete_user_event_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Mutations::DeleteUserEvent, type: :request do
 
       expect(UserEvent.count).to eq(2)
 
-      post '/graphql', params: { query: destroy_query(id: @rsvp.id) }
+      post '/graphql', params: { query: destroy_query(user_id: @user2.id, event_id: @event1.id) }
 
       json = JSON.parse(response.body)
-      
+
       data = json['data']['deleteUserEvent']
 
       expect(data).to include(
@@ -29,11 +29,12 @@ RSpec.describe Mutations::DeleteUserEvent, type: :request do
     end
   end
 
-  def destroy_query(id:)
+  def destroy_query(user_id:, event_id:)
     <<~GQL
       mutation {
         deleteUserEvent(input: {
-          id: #{id}
+          userId: #{user_id}
+          eventId: #{event_id}
        }) {
           userId
           eventId


### PR DESCRIPTION
## What this PR Covers  
Changes the delete user event to take in user and event id argument instead of a UserEvent id
  
## Type of Content in PR  

- [x] Spec Files
- [ ] Controllers / Facades / Poros
- [ ] Service Requests
- [ ] Route Change
- [ ] Gemfile Update
- [x] Other:  


Is this a fully completed API Endpoint?  

- [x] yes - API Endpoint: 
- [ ] no  

## Simplecov 100% Coverage  
- [ ] yes
- [x] no  
If no, what files are not being covered?  

## Tested on Localhost/Postman  
- [x] yes
- [ ] no  
If no, why was it not?  

## Additional Comments